### PR TITLE
Mod1+train loss opt

### DIFF
--- a/conf/train.yaml
+++ b/conf/train.yaml
@@ -32,7 +32,7 @@ hydra:
 training:
   seed: 0
   epochs: 50
-  batch_size: 10 # should >= nodes * tasks_per_node
+  batch_size: 5 # should >= nodes * tasks_per_node
   save_every_x_epoch: 1
   reconstruct_every_x_batch: 500
   num_reconstruct_samples: 6
@@ -77,6 +77,9 @@ model:
   train_decoder: True
   train_bisim: True  # Control whether to train the bisimulation model
 
+  train_w_std_loss: True
+  train_w_reward_loss: True
+  
 debug: False 
 
 # Planning params for planning eval jobs launched during training

--- a/conf/train.yaml
+++ b/conf/train.yaml
@@ -32,7 +32,7 @@ hydra:
 training:
   seed: 0
   epochs: 50
-  batch_size: 5 # should >= nodes * tasks_per_node
+  batch_size: 10 # should >= nodes * tasks_per_node
   save_every_x_epoch: 1
   reconstruct_every_x_batch: 500
   num_reconstruct_samples: 6
@@ -67,6 +67,8 @@ num_pred: 1 # only supports 1
 has_predictor: True # set this to False for only training a decoder
 has_decoder: True # set this to False for only training a predictor
 
+accelerate_launch: False
+
 model:
   _target_: models.visual_world_model.VWorldModel
   image_size: ${img_size}
@@ -79,7 +81,7 @@ model:
 
   train_w_std_loss: True
   train_w_reward_loss: True
-  
+
 debug: False 
 
 # Planning params for planning eval jobs launched during training

--- a/models/bisim.py
+++ b/models/bisim.py
@@ -86,7 +86,7 @@ class BisimModel(nn.Module):
         # print(f"DEBUG - BisimModel.predict_reward concatenated input: {x.shape}")
         return self.reward(x)
     
-    def calc_bisim_loss(self, z_bisim, z_bisim2, reward, reward2, next_z_bisim, next_z_bisim2, discount=0.99):
+    def calc_bisim_loss(self, z_bisim, z_bisim2, reward, reward2, next_z_bisim, next_z_bisim2, discount=0.99, train_w_reward_loss=True):
         """
         Calculate bisimulation loss
         bisimulation metric: d(s1,s2) = |r(s1) - r(s2)| + γ · d(P(s1), P(s2))
@@ -104,7 +104,11 @@ class BisimModel(nn.Module):
         transition_dist = torch.norm(next_z_bisim - next_z_bisim2, dim=-1)
         
         # Target bisimilarity
-        target_bisimilarity = r_dist + discount * transition_dist
+        # if want reward_loss
+        if train_w_reward_loss:
+            target_bisimilarity = r_dist + discount * transition_dist
+        else:
+            target_bisimilarity = 0*r_dist + discount * transition_dist
         
         # Bisimulation loss
         bisim_loss = (z_dist - target_bisimilarity).pow(2)

--- a/train.py
+++ b/train.py
@@ -151,11 +151,15 @@ class Trainer:
         self.train_predictor = self.cfg.model.train_predictor
         self.train_decoder = self.cfg.model.train_decoder
         self.train_bisim = self.cfg.model.get('train_bisim', True)  # Control training of bisimulation model
-        log.info(f"Train encoder, predictor, decoder, bisim:\
+        self.train_w_std_loss = self.cfg.model.get('train_w_std_loss', True)
+        self.train_w_reward_loss = self.cfg.model.get('train_w_reward_loss', True)
+        log.info(f"Train encoder, predictor, decoder, bisim, train_w_std_loss, train_w_reward_loss:\
             {self.cfg.model.train_encoder},\
             {self.cfg.model.train_predictor},\
             {self.cfg.model.train_decoder},\
-            {self.train_bisim}")
+            {self.train_bisim},\
+            {self.train_w_std_loss},\
+            {self.train_w_reward_loss}")
 
         self._keys_to_save = [
             "epoch",
@@ -347,6 +351,8 @@ class Trainer:
             num_proprio_repeat=self.cfg.num_proprio_repeat,
             bisim_coef=self.cfg.get('bisim_coef', 1.0),
             train_bisim=self.train_bisim,
+            train_w_std_loss=self.train_w_std_loss,
+            train_w_reward_loss=self.train_w_reward_loss,
         )
 
     def init_optimizers(self):

--- a/train.py
+++ b/train.py
@@ -153,6 +153,7 @@ class Trainer:
         self.train_bisim = self.cfg.model.get('train_bisim', True)  # Control training of bisimulation model
         self.train_w_std_loss = self.cfg.model.get('train_w_std_loss', True)
         self.train_w_reward_loss = self.cfg.model.get('train_w_reward_loss', True)
+        self.accelerate = self.cfg.model.get('accelerate_launch', False)
         log.info(f"Train encoder, predictor, decoder, bisim, train_w_std_loss, train_w_reward_loss:\
             {self.cfg.model.train_encoder},\
             {self.cfg.model.train_predictor},\
@@ -347,12 +348,15 @@ class Trainer:
             proprio_dim=proprio_emb_dim,
             action_dim=action_emb_dim,
             concat_dim=self.cfg.concat_dim,
+            bisim_latent_dim=self.cfg.get('bisim_latent_dim', 64),
+            bisim_hidden_dim=self.cfg.get('bisim_hidden_dim', 256),
             num_action_repeat=self.cfg.num_action_repeat,
             num_proprio_repeat=self.cfg.num_proprio_repeat,
             bisim_coef=self.cfg.get('bisim_coef', 1.0),
             train_bisim=self.train_bisim,
             train_w_std_loss=self.train_w_std_loss,
             train_w_reward_loss=self.train_w_reward_loss,
+            accelerate=self.accelerate
         )
 
     def init_optimizers(self):


### PR DESCRIPTION
Two new parameter in training: `train_w_std_loss` and `train_w_reward_loss` in train.yaml, controls if standard and/or reward loss be used in training or not. Control these parameter example `model.train_w_std_loss=False model.train_w_reward_loss=False`, to disable both loss in training

New functionality: Distributed training uses accelerate python package, usage example: `accelerate launch --num_processes=2 --num_machines=1 --mixed_precision=no --dynamo_backend=no train.py --config-name train.yaml env=point_maze frameskip=5 num_hist=3 accelerate=True` , where --num_processes=2 indicates 2 GPUs are used, note the batch size should be always divisible by num_processes.